### PR TITLE
Background Size Bug

### DIFF
--- a/web/frontend/src/css/tourneygen.css
+++ b/web/frontend/src/css/tourneygen.css
@@ -13,8 +13,15 @@
 
 /* This is so the body can be the whole page instead of
     whatever fills it up (needed for flex) */
+html {
+	height: 100%;
+}
+
+body {
+	min-height: 100%;
+}
+
 html, body {
-    height: 100%;
     margin: 0;
 }
 


### PR DESCRIPTION
If there are multiple teams in a league, the height of the body of the document will stretch past the size of the document.

Steps to recreate: continue to  add leagues until a white bar appears at the bottom of the screen